### PR TITLE
feat(issue-key): show issue keys in parent_changed activity feed

### DIFF
--- a/.product/CURRENT.md
+++ b/.product/CURRENT.md
@@ -1,6 +1,6 @@
 # Current session
 
-**Updated:** 2026-05-28
+**Updated:** 2026-06-05
 
 ## Session question (60–90 min)
 
@@ -12,6 +12,7 @@
 - [x] Issue detail header shows the key with **copy to clipboard**.
 - [x] GitHub sidebar hints reference `{issueKey}-…` (not numeric `issue.id`).
 - [x] Sub-issues and filters use the key where the parent/child is labeled.
+- [x] Activity feed `parent_changed` entries use issue keys (never `#id`).
 - [ ] Manual check: copy key → create or push branch `KEY-slug` → linked branch appears (local stack).
 - [x] Notifications show `issueKey` (with `#id` fallback for older payloads).
 

--- a/.product/tasks/01-issue-key-surfacing.md
+++ b/.product/tasks/01-issue-key-surfacing.md
@@ -31,7 +31,7 @@ Backend allocates stable keys (`EPV1-93`) and webhooks link branches by key, but
 - [x] Notifications: add `issueKey` to API payloads (`IssueAssigned`, `DueDate`, etc.) and UI
 - [x] Issue picker shows key
 - [x] GitHub branch name suggestion uses `issueKey` (not numeric id)
-- [ ] Activity feed entries reference key where relevant
+- [x] Activity feed entries reference key where relevant
 
 ## Decisions
 

--- a/api/src/project/application/features/issue/find-issue-feed.query.ts
+++ b/api/src/project/application/features/issue/find-issue-feed.query.ts
@@ -15,11 +15,16 @@ import {
   IssueRepository,
 } from 'src/project/infrastructure/repositories';
 import { parseStoredIssueActivityPayload } from 'src/project/domain/utils/issue-activity-payload-parse';
+import {
+  collectParentIssueIdsNeedingKeys,
+  enrichParentChangedPayload,
+} from 'src/project/domain/utils/parent-changed-activity-payload';
 import { IssuerUserIsNotWorkspaceMember } from 'src/workspace/domain/exceptions';
 import { WorkspaceRepository } from 'src/workspace/infrastructure/repositories';
 import type {
   IssueActivityPayload,
   IssueActivityType,
+  ParentChangedPayload,
 } from 'src/project/domain/types/issue-activity-payload.types';
 import { IsOptional, Max, Min, IsNumber } from 'class-validator';
 import { MessageReply } from 'src/channel/domain/entities';
@@ -140,6 +145,27 @@ export class FindIssueFeedQuery implements IQueryHandler<FindIssueFeed> {
         : [];
     const actorById = new Map(actorRows.map((u) => [u.id, u]));
 
+    const parsedPayloads = rows.map((row) =>
+      row.type === 'parent_changed'
+        ? ((parseStoredIssueActivityPayload(
+            row.type,
+            (row.payload as Record<string, unknown> | null) ?? null,
+          ) ?? null) as ParentChangedPayload | null)
+        : null,
+    );
+    const parentIdsNeedingKeys =
+      collectParentIssueIdsNeedingKeys(parsedPayloads);
+    const parentKeyRows =
+      parentIdsNeedingKeys.length > 0
+        ? await this.issueRepo.find({
+            where: { id: In(parentIdsNeedingKeys) },
+            select: { id: true, issueKey: true },
+          })
+        : [];
+    const parentKeysByIssueId = new Map(
+      parentKeyRows.map((row) => [row.id, row.issueKey]),
+    );
+
     const items: IIssueFeedActivityItem[] = rows.map((a) => {
       const dto = a.messageId ? messagesById.get(a.messageId) : undefined;
       const replyPreviews = a.messageId
@@ -151,6 +177,19 @@ export class FindIssueFeedQuery implements IQueryHandler<FindIssueFeed> {
 
       const actorUser =
         a.actorId != null ? actorById.get(a.actorId) : undefined;
+
+      let payload =
+        parseStoredIssueActivityPayload(
+          a.type,
+          (a.payload as Record<string, unknown> | null) ?? null,
+        ) ?? null;
+
+      if (a.type === 'parent_changed' && payload != null) {
+        payload = enrichParentChangedPayload(
+          payload as ParentChangedPayload,
+          parentKeysByIssueId,
+        );
+      }
 
       return {
         activityId: a.id,
@@ -168,11 +207,7 @@ export class FindIssueFeedQuery implements IQueryHandler<FindIssueFeed> {
         createdAt: a.createdAt,
         messageId: a.messageId,
         attachmentId: a.attachmentId,
-        payload:
-          parseStoredIssueActivityPayload(
-            a.type,
-            (a.payload as Record<string, unknown> | null) ?? null,
-          ) ?? null,
+        payload,
         message: dto ?? null,
         replyPreviews: replyPreviews,
         repliesTotal: a.messageId != null ? repliesTotal : undefined,

--- a/api/src/project/application/features/issue/update-issue.command.ts
+++ b/api/src/project/application/features/issue/update-issue.command.ts
@@ -21,7 +21,9 @@ import {
   TIPTAP_ISSUE_DESCRIPTION_ACTIVITY_EXCERPT_MAX,
 } from 'src/utils/tiptap-excerpt';
 import { WorkspaceRepository } from 'src/workspace/infrastructure/repositories';
+import { buildParentChangedPayload } from 'src/project/domain/utils/parent-changed-activity-payload';
 import { Transactional } from 'typeorm-transactional';
+import { In } from 'typeorm';
 import { ProjectGateway } from '../../gateways/project.gateway';
 import { syncIssueDueDateReminders } from './sync-issue-due-reminders';
 
@@ -215,6 +217,26 @@ export class UpdateIssueCommand implements ICommandHandler<UpdateIssue> {
       data.parentIssueId !== undefined &&
       (savedIssue.parentIssueId ?? null) !== prevSnapshot.parentIssueId
     ) {
+      const previousParentIssueId = prevSnapshot.parentIssueId;
+      const newParentIssueId = savedIssue.parentIssueId ?? null;
+      const parentIds = [
+        ...new Set(
+          [previousParentIssueId, newParentIssueId].filter(
+            (id): id is number => id != null,
+          ),
+        ),
+      ];
+      const parentRows =
+        parentIds.length > 0
+          ? await this.issueRepo.find({
+              where: { id: In(parentIds) },
+              select: { id: true, issueKey: true },
+            })
+          : [];
+      const keysByIssueId = new Map(
+        parentRows.map((row) => [row.id, row.issueKey]),
+      );
+
       await this.issueActivities.save(
         this.issueActivities.create({
           issueId,
@@ -222,10 +244,11 @@ export class UpdateIssueCommand implements ICommandHandler<UpdateIssue> {
           type: 'parent_changed',
           messageId: null,
           attachmentId: null,
-          payload: {
-            previousParentIssueId: prevSnapshot.parentIssueId,
-            newParentIssueId: savedIssue.parentIssueId ?? null,
-          },
+          payload: buildParentChangedPayload({
+            previousParentIssueId,
+            newParentIssueId,
+            keysByIssueId,
+          }),
         }),
       );
     }

--- a/api/src/project/domain/__tests__/parent-changed-activity-payload.spec.ts
+++ b/api/src/project/domain/__tests__/parent-changed-activity-payload.spec.ts
@@ -1,0 +1,77 @@
+import {
+  buildParentChangedPayload,
+  collectParentIssueIdsNeedingKeys,
+  enrichParentChangedPayload,
+} from '../utils/parent-changed-activity-payload';
+
+describe('parent-changed-activity-payload', () => {
+  const keys = new Map<number, string>([
+    [10, 'EPV1-10'],
+    [12, 'EPV1-12'],
+  ]);
+
+  it('buildParentChangedPayload includes issue keys from lookup', () => {
+    expect(
+      buildParentChangedPayload({
+        previousParentIssueId: 10,
+        newParentIssueId: 12,
+        keysByIssueId: keys,
+      }),
+    ).toEqual({
+      previousParentIssueId: 10,
+      newParentIssueId: 12,
+      previousParentIssueKey: 'EPV1-10',
+      newParentIssueKey: 'EPV1-12',
+    });
+  });
+
+  it('collectParentIssueIdsNeedingKeys skips rows that already have keys', () => {
+    expect(
+      collectParentIssueIdsNeedingKeys([
+        {
+          previousParentIssueId: 10,
+          newParentIssueId: 12,
+        },
+        {
+          previousParentIssueId: 99,
+          newParentIssueId: null,
+          previousParentIssueKey: 'EPV1-99',
+        },
+      ]),
+    ).toEqual([10, 12]);
+  });
+
+  it('enrichParentChangedPayload merges keys for legacy ID-only payloads', () => {
+    expect(
+      enrichParentChangedPayload(
+        {
+          previousParentIssueId: 10,
+          newParentIssueId: 12,
+        },
+        keys,
+      ),
+    ).toEqual({
+      previousParentIssueId: 10,
+      newParentIssueId: 12,
+      previousParentIssueKey: 'EPV1-10',
+      newParentIssueKey: 'EPV1-12',
+    });
+  });
+
+  it('enrichParentChangedPayload leaves keys null when issue row is missing', () => {
+    expect(
+      enrichParentChangedPayload(
+        {
+          previousParentIssueId: 404,
+          newParentIssueId: null,
+        },
+        keys,
+      ),
+    ).toEqual({
+      previousParentIssueId: 404,
+      newParentIssueId: null,
+      previousParentIssueKey: null,
+      newParentIssueKey: null,
+    });
+  });
+});

--- a/api/src/project/domain/types/issue-activity-payload.types.ts
+++ b/api/src/project/domain/types/issue-activity-payload.types.ts
@@ -49,6 +49,8 @@ export type LabelsChangedPayload = {
 export type ParentChangedPayload = {
   previousParentIssueId?: number | null;
   newParentIssueId?: number | null;
+  previousParentIssueKey?: string | null;
+  newParentIssueKey?: string | null;
 };
 export type EmptyPayload = Record<string, never>;
 

--- a/api/src/project/domain/utils/parent-changed-activity-payload.ts
+++ b/api/src/project/domain/utils/parent-changed-activity-payload.ts
@@ -1,0 +1,68 @@
+import type { ParentChangedPayload } from '../types/issue-activity-payload.types';
+
+export type ParentIssueKeyLookup = ReadonlyMap<number, string>;
+
+export function issueKeyForParentId(
+  lookup: ParentIssueKeyLookup,
+  id: number | null | undefined,
+): string | null {
+  if (id == null) return null;
+  const key = lookup.get(id)?.trim();
+  return key || null;
+}
+
+export function buildParentChangedPayload(params: {
+  previousParentIssueId: number | null;
+  newParentIssueId: number | null;
+  keysByIssueId: ParentIssueKeyLookup;
+}): ParentChangedPayload {
+  return {
+    previousParentIssueId: params.previousParentIssueId,
+    newParentIssueId: params.newParentIssueId,
+    previousParentIssueKey: issueKeyForParentId(
+      params.keysByIssueId,
+      params.previousParentIssueId,
+    ),
+    newParentIssueKey: issueKeyForParentId(
+      params.keysByIssueId,
+      params.newParentIssueId,
+    ),
+  };
+}
+
+export function collectParentIssueIdsNeedingKeys(
+  payloads: Array<ParentChangedPayload | null | undefined>,
+): number[] {
+  const ids = new Set<number>();
+  for (const payload of payloads) {
+    if (!payload) continue;
+    if (
+      payload.previousParentIssueId != null &&
+      !payload.previousParentIssueKey?.trim()
+    ) {
+      ids.add(payload.previousParentIssueId);
+    }
+    if (
+      payload.newParentIssueId != null &&
+      !payload.newParentIssueKey?.trim()
+    ) {
+      ids.add(payload.newParentIssueId);
+    }
+  }
+  return [...ids];
+}
+
+export function enrichParentChangedPayload(
+  payload: ParentChangedPayload,
+  keysByIssueId: ParentIssueKeyLookup,
+): ParentChangedPayload {
+  return {
+    ...payload,
+    previousParentIssueKey:
+      payload.previousParentIssueKey?.trim() ||
+      issueKeyForParentId(keysByIssueId, payload.previousParentIssueId),
+    newParentIssueKey:
+      payload.newParentIssueKey?.trim() ||
+      issueKeyForParentId(keysByIssueId, payload.newParentIssueId),
+  };
+}

--- a/app/src/domain/issues/issue-activity-feed-text.test.ts
+++ b/app/src/domain/issues/issue-activity-feed-text.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { formatIssueActivitySentence } from "./issue-activity-feed-text";
+import type { IssueFeedItem } from "./types";
+
+const peersById = new Map();
+
+function parentChangedItem(payload: Record<string, unknown>): IssueFeedItem {
+  return {
+    activityId: 1,
+    issueId: 1,
+    type: "parent_changed",
+    actorId: 1,
+    actor: { id: 1, name: "Ada", picture: null },
+    createdAt: new Date().toISOString(),
+    messageId: null,
+    attachmentId: null,
+    payload,
+    message: null,
+    replyPreviews: [],
+  };
+}
+
+describe("formatIssueActivitySentence parent_changed", () => {
+  it("uses issue keys when both are known", () => {
+    expect(
+      formatIssueActivitySentence(
+        parentChangedItem({
+          previousParentIssueId: 10,
+          newParentIssueId: 12,
+          previousParentIssueKey: "EPV1-10",
+          newParentIssueKey: "EPV1-12",
+        }),
+        peersById,
+      ),
+    ).toBe("Ada changed parent issue from EPV1-10 to EPV1-12");
+  });
+
+  it("uses generic copy when keys are missing (never numeric id)", () => {
+    expect(
+      formatIssueActivitySentence(
+        parentChangedItem({
+          previousParentIssueId: 10,
+          newParentIssueId: 12,
+        }),
+        peersById,
+      ),
+    ).toBe("Ada changed the parent issue");
+
+    expect(
+      formatIssueActivitySentence(
+        parentChangedItem({
+          newParentIssueId: 12,
+        }),
+        peersById,
+      ),
+    ).toBe("Ada set a parent issue");
+
+    expect(
+      formatIssueActivitySentence(
+        parentChangedItem({
+          previousParentIssueId: 10,
+          newParentIssueId: null,
+        }),
+        peersById,
+      ),
+    ).toBe("Ada removed the parent issue");
+  });
+
+  it("formats set and remove when keys are present", () => {
+    expect(
+      formatIssueActivitySentence(
+        parentChangedItem({
+          newParentIssueId: 12,
+          newParentIssueKey: "EPV1-12",
+        }),
+        peersById,
+      ),
+    ).toBe("Ada set parent issue to EPV1-12");
+
+    expect(
+      formatIssueActivitySentence(
+        parentChangedItem({
+          previousParentIssueId: 10,
+          newParentIssueId: null,
+          previousParentIssueKey: "EPV1-10",
+        }),
+        peersById,
+      ),
+    ).toBe("Ada removed parent issue (was EPV1-10)");
+  });
+
+  it("does not include hash-id patterns in output", () => {
+    const sentence = formatIssueActivitySentence(
+      parentChangedItem({
+        previousParentIssueId: 10,
+        newParentIssueId: 12,
+      }),
+      peersById,
+    );
+    expect(sentence).not.toMatch(/#\d+/);
+  });
+});

--- a/app/src/domain/issues/issue-activity-feed-text.ts
+++ b/app/src/domain/issues/issue-activity-feed-text.ts
@@ -90,6 +90,30 @@ function resolveLabelNames(raw: unknown): string[] {
   return raw.filter((x): x is string => typeof x === "string" && x.trim() !== "");
 }
 
+function resolveParentIssueKey(
+  payload: Record<string, unknown> | null,
+  field: "previousParentIssueKey" | "newParentIssueKey",
+): string | null {
+  const raw = payload?.[field];
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  return trimmed || null;
+}
+
+function parentWasSet(payload: Record<string, unknown> | null): boolean {
+  return payload?.newParentIssueId != null;
+}
+
+function parentWasRemoved(payload: Record<string, unknown> | null): boolean {
+  return payload?.previousParentIssueId != null && payload?.newParentIssueId == null;
+}
+
+function parentWasChanged(payload: Record<string, unknown> | null): boolean {
+  const prev = payload?.previousParentIssueId;
+  const next = payload?.newParentIssueId;
+  return prev != null && next != null && prev !== next;
+}
+
 /** One plain sentence: "Ada changed status to Done", "Harry added Feature label". */
 export function formatIssueActivitySentence(
   item: IssueFeedItem,
@@ -160,14 +184,22 @@ export function formatIssueActivitySentence(
       return `${name} updated labels`;
     }
     case "parent_changed": {
-      const prevRaw = p?.previousParentIssueId;
-      const nextRaw = p?.newParentIssueId;
-      const prev = typeof prevRaw === "number" ? prevRaw : null;
-      const next = typeof nextRaw === "number" ? nextRaw : null;
-      if (next != null && prev != null && prev !== next)
-        return `${name} changed parent issue from #${prev} to #${next}`;
-      if (next != null) return `${name} set parent issue to #${next}`;
-      if (prev != null) return `${name} removed parent issue (was #${prev})`;
+      const prevKey = resolveParentIssueKey(p, "previousParentIssueKey");
+      const nextKey = resolveParentIssueKey(p, "newParentIssueKey");
+      if (parentWasChanged(p)) {
+        if (prevKey && nextKey) {
+          return `${name} changed parent issue from ${prevKey} to ${nextKey}`;
+        }
+        return `${name} changed the parent issue`;
+      }
+      if (parentWasSet(p)) {
+        if (nextKey) return `${name} set parent issue to ${nextKey}`;
+        return `${name} set a parent issue`;
+      }
+      if (parentWasRemoved(p)) {
+        if (prevKey) return `${name} removed parent issue (was ${prevKey})`;
+        return `${name} removed the parent issue`;
+      }
       return `${name} updated parent issue`;
     }
     case "attachment_added":


### PR DESCRIPTION
Persist and hydrate parent issue keys on write/read so activity sentences use EPV1-style keys with generic copy when unresolved, never numeric #id.